### PR TITLE
Deploy astar-website under gstar.newturing.ai/2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-bootcamp",
-  "homepage": "https://gstar.newturing.ai/",
+  "homepage": "https://gstar.newturing.ai/2025",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/images/newturing_ai.png" />
+    <link rel="icon" href="%PUBLIC_URL%/images/newturing_ai.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />


### PR DESCRIPTION
## Summary
- Set `homepage` to `https://gstar.newturing.ai/2025` so built asset URLs resolve correctly under the new subpath
- Fixed a hardcoded favicon path (`/images/newturing_ai.png`) to use `%PUBLIC_URL%` so it does not 404 once served off domain-root

## Context
The site now runs on `https://gstar.newturing.ai/2025`

## Test plan
- [x] Rebuilt and verified `https://gstar.newturing.ai/2025/` returns 200 with correctly-prefixed asset paths
- [x] Verified static JS/CSS and favicon load without 404s
- [x] Verified `gstar.newturing.ai/` (existing app) is unaffected